### PR TITLE
Added support for watchOS 6 and up

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "LightChart",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(


### PR DESCRIPTION
Had some issues running LightChart on WatchOs and this should fix it.